### PR TITLE
fix: adjust regex isSlug

### DIFF
--- a/src/lib/isSlug.js
+++ b/src/lib/isSlug.js
@@ -1,6 +1,6 @@
 import assertString from './util/assertString';
 
-let charsetRegex = /^[^\s-_](?!.*?[-_]{2,})[a-z0-9-\\][^\s]*[^-_\s]$/;
+let charsetRegex = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/i;
 
 export default function isSlug(str) {
   assertString(str);

--- a/test/validators.test.js
+++ b/test/validators.test.js
@@ -12345,8 +12345,6 @@ describe('Validators', () => {
         'foo_bar',
         'foo-bar-foo',
         'foo-bar_foo',
-        'foo-bar_foo*75-b4r-**_foo',
-        'foo-bar_foo*75-b4r-**_foo-&&',
       ],
       invalid: [
         'not-----------slug',
@@ -12356,6 +12354,10 @@ describe('Validators', () => {
         '_not-slug',
         'not-slug_',
         'not slug',
+        'foo-bar_foo75-b4r-foo-',
+        'foo-bar_foo75-b4r-**_foo',
+        'foo-bar_foo75-b4r-**_foo-',
+        '€test',
       ],
     });
   });


### PR DESCRIPTION
# Pull request de Bug [#](https://github.com/upe-garanhuns/msw-gama-2022/issues/1)2: Corrigir regex isSlug que está permitindo caracteres especiais

## **1)** Descrição da CR:

Essa Pull Request tem como objetivo verificar urls inválidas na função isSlug do Validator. A correção se deu por uma ajuste na regex principal do método.

## 2) **Link para CR:**

- Link para a CR inicial: [Clique aqui](https://github.com/upe-garanhuns/msw-gama-2022/issues/8)
- Link para a CR de análise de impacto: [Clique aqui](https://github.com/upe-garanhuns/msw-gama-2022/issues/20)

## 3) Tempo estimado para a mudança:

> Foram estimadas 4 a 8 horas para implementação dessa mudança.
> 

## 4) Tempo gasto para realizar a mudança:

> Foram gastas 3 horas para implementação dessa mudança.
> 

## 5) Lista de artefatos para alteração estimados pela análise:

- test/validators.test.js
- src/lib/isSlug

## 6) Lista de artefatos alterados pela implementação:

- test/validators.test.js
- src/lib/isSlug

## 7) Screenshot antes da implementação:

![Untitled](https://i.imgur.com/HTO0sGa.png)

## 8) Screenshot depois da implementação:

![Untitled](https://i.imgur.com/e9cvl0E.png)

## 9) Testes:

**Passos para reproduzir:**

- Rodar: npm test

**Passos para validar:**

- Verificar a saída (se há algum teste falho)